### PR TITLE
Add basic tests and lazy TensorFlow import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/capricorn_ai/models.py
+++ b/capricorn_ai/models.py
@@ -3,7 +3,12 @@
 Loader functions for pre-trained Keras models.
 """
 import os
-from tensorflow.keras.models import load_model as keras_load_model
+
+# Import TensorFlow lazily to avoid heavy dependency at module import time
+try:
+    from tensorflow.keras.models import load_model as keras_load_model
+except Exception:  # pragma: no cover - optional dependency
+    keras_load_model = None
 
 # Point at our package’s keras_models/ folder, not the old top-level models/
 default_models_dir = os.path.join(
@@ -31,5 +36,9 @@ def get_model_path(name):
 
 def load_model(name):
     """Load and return the Keras model for the given name."""
+    if keras_load_model is None:
+        raise ImportError(
+            "TensorFlow is required to load models but is not installed."
+        )
     path = get_model_path(name)
     return keras_load_model(path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,25 @@
+import sys
+import types
+import pytest
+
+# Stub out heavy dependencies before importing the package
+numpy_stub = types.ModuleType('numpy')
+numpy_stub.ndarray = object
+sys.modules.setdefault('numpy', numpy_stub)
+
+pil_stub = types.ModuleType('PIL')
+image_stub = types.ModuleType('PIL.Image')
+pil_stub.Image = image_stub
+sys.modules.setdefault('PIL', pil_stub)
+sys.modules.setdefault('PIL.Image', image_stub)
+
+from capricorn_ai.models import list_models, get_model_path
+
+
+def test_list_models_contains_capricorn():
+    assert 'capricorn0.1' in list_models()
+
+
+def test_get_model_path_invalid():
+    with pytest.raises(ValueError):
+        get_model_path('unknown-model')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import sys
+import types
+
+# Stub out heavy dependencies so the module can import without them installed
+numpy_stub = types.ModuleType('numpy')
+numpy_stub.ndarray = object
+sys.modules.setdefault('numpy', numpy_stub)
+
+pil_stub = types.ModuleType('PIL')
+image_stub = types.ModuleType('PIL.Image')
+pil_stub.Image = image_stub
+sys.modules.setdefault('PIL', pil_stub)
+sys.modules.setdefault('PIL.Image', image_stub)
+
+from capricorn_ai.utils import _categorize
+
+
+def test_categorize_mapping():
+    assert _categorize('mucus') == 'Colon Histology'
+    assert _categorize('melanoma') == 'Skin Bathology'
+    assert _categorize('platelet') == 'Blood Smear'
+    assert _categorize('not-a-label') == 'Unknown'


### PR DESCRIPTION
## Summary
- lazily import TensorFlow in `models.py` so the package can be imported without it
- ignore cache directories
- add tests for model helper functions and `_categorize`

## Testing
- `pytest -q`