### PR TITLE
Allow using tf-nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ cd capricorn
 # Install dependencies
 pip install -r requirements.txt
 
+# Install TensorFlow (use the stable release or the tf-nightly build)
+pip install tensorflow  # or tf-nightly
+
 # Install as a package
 pip install capricorn-ai
 ```
@@ -69,7 +72,7 @@ for label, confidence in label_confidences(probs):
 
 ## Development & Testing
 
-* Dependencies are in `requirements.txt`.
+* Dependencies are in `requirements.txt` (install `tensorflow` or `tf-nightly` separately).
 * Run tests with:
 
   ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ description = "Deep learning histopathology classification with Keras"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-  "tensorflow>=2.0",
   "numpy>=1.19",
   "Pillow>=8.0",
 ]
+
 authors = [
   { name="Moshe Newman" },
 ]
@@ -27,6 +27,10 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
+
+[project.optional-dependencies]
+tensorflow = ["tensorflow>=2.0"]
+tf-nightly = ["tf-nightly>=2.0"]
 
 [project.urls]
 "Homepage"   = "https://github.com/SigMoses/Capricorn"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow>=2.10.0
+# Install either the stable TensorFlow package or the tf-nightly build
 numpy>=1.19.5
 Pillow>=8.0.0


### PR DESCRIPTION
## Summary
- allow tf-nightly by moving `tensorflow` to optional dependencies
- document how to install TensorFlow in README
- update requirements.txt to leave TensorFlow installation up to the user

## Testing
- `git status --short`
